### PR TITLE
Enable to use a specific branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ $ testdrive Unbox -p tvOS
 
 🚓  Use a specific version or branch for your test drive (the latest version is used by default):
 ```
-$ testdrive Unbox -c 2.3.0
-$ testdrive Unbox -c swift3
+$ testdrive Unbox -v 2.3.0
+$ testdrive Unbox -v swift3
 $ testdrive Wrap --master
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ $ testdrive Unbox -p tvOS
 
 🚓  Use a specific version or branch for your test drive (the latest version is used by default):
 ```
-$ testdrive Unbox -v 2.3.0
-$ testdrive Unbox -b swift3
+$ testdrive Unbox -c 2.3.0
+$ testdrive Unbox -c swift3
 $ testdrive Wrap --master
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ $ testdrive Unbox Wrap
 $ testdrive Unbox -p tvOS
 ```
 
-🚓  Use a specific version for your test drive (the latest version is used by default):
+🚓  Use a specific version or branch for your test drive (the latest version is used by default):
 ```
 $ testdrive Unbox -v 2.3.0
+$ testdrive Unbox -b swift3
 $ testdrive Wrap --master
 ```
 

--- a/Sources/TestDrive.swift
+++ b/Sources/TestDrive.swift
@@ -36,10 +36,10 @@ extension CommandLine {
             switch argument {
             case "--platform", "-p":
                 expectingPlatform = true
+            case "--version", "-v":
+                expectingCheckout = true
             case "--master", "-m":
                 parsedArguments.addTagToLastTarget(.master)
-            case "--checkout", "-c":
-                expectingCheckout = true
             default:
                 let target = try Target(kind: targetKind(from: argument), tag: .latestVersion)
                 parsedArguments.targets.append(target)
@@ -259,13 +259,13 @@ func printHelp() {
     print("\nUsage:")
     print("- Simply pass a list of pod names or URLs that you want to test drive.")
     print("- You can also specify a platform (iOS, macOS or tvOS) using the '-p' option")
-    print("- To use a specific version or branch, use the '-c' argument (or '-m' for master)")
+    print("- To use a specific version or branch, use the '-v' argument (or '-m' for master)")
     print("\nExamples:")
     print("- testdrive Unbox Wrap Files")
     print("- testdrive https://github.com/johnsundell/unbox.git Wrap Files")
     print("- testdrive Unbox -p tvOS")
-    print("- testdrive Unbox -c 2.3.0")
-    print("- testdrive Unbox -c swift3")
+    print("- testdrive Unbox -v 2.3.0")
+    print("- testdrive Unbox -v swift3")
 }
 
 // MARK: - Script

--- a/Sources/TestDrive.swift
+++ b/Sources/TestDrive.swift
@@ -17,6 +17,7 @@ extension CommandLine {
         var parsedArguments = Arguments()
         var expectingPlatform = false
         var expectingVersion = false
+        var expectingBranch = false
 
         for argument in arguments[1..<arguments.count] {
             if expectingPlatform {
@@ -32,6 +33,11 @@ extension CommandLine {
                 parsedArguments.addTagToLastTarget(.version(version))
                 expectingVersion = false
                 continue
+            } else if expectingBranch {
+                let branch = argument
+                parsedArguments.addTagToLastTarget(.branch(branch))
+                expectingBranch = false
+                continue
             }
 
             switch argument {
@@ -41,6 +47,8 @@ extension CommandLine {
                 expectingVersion = true
             case "--master", "-m":
                 parsedArguments.addTagToLastTarget(.master)
+            case "--branch", "-b":
+                expectingBranch = true
             default:
                 let target = try Target(kind: targetKind(from: argument), tag: .latestVersion)
                 parsedArguments.targets.append(target)
@@ -121,6 +129,7 @@ extension Arguments {
 
 enum Tag {
     case master
+    case branch(String)
     case version(Version)
     case latestVersion
 }
@@ -245,6 +254,8 @@ class PackageLoader {
             return latestVersion.string
         case .master:
             return "master"
+        case .branch(let branch):
+            return branch
         case .version(let version):
             return version.string
         }
@@ -266,6 +277,7 @@ func printHelp() {
     print("- testdrive https://github.com/johnsundell/unbox.git Wrap Files")
     print("- testdrive Unbox -p tvOS")
     print("- testdrive Unbox -v 2.3.0")
+    print("- testdrive Unbox -b swift3")
 }
 
 // MARK: - Script

--- a/Sources/TestDrive.swift
+++ b/Sources/TestDrive.swift
@@ -16,8 +16,7 @@ extension CommandLine {
     static func parseArguments() throws -> Arguments {
         var parsedArguments = Arguments()
         var expectingPlatform = false
-        var expectingVersion = false
-        var expectingBranch = false
+        var expectingCheckout = false
 
         for argument in arguments[1..<arguments.count] {
             if expectingPlatform {
@@ -28,27 +27,19 @@ extension CommandLine {
                 parsedArguments.platform = platform
                 expectingPlatform = false
                 continue
-            } else if expectingVersion {
-                let version = try Version(string: argument)
-                parsedArguments.addTagToLastTarget(.version(version))
-                expectingVersion = false
-                continue
-            } else if expectingBranch {
-                let branch = argument
-                parsedArguments.addTagToLastTarget(.branch(branch))
-                expectingBranch = false
+            } else if expectingCheckout {
+                parsedArguments.addTagToLastTarget(.checkout(argument))
+                expectingCheckout = false
                 continue
             }
 
             switch argument {
             case "--platform", "-p":
                 expectingPlatform = true
-            case "--version", "-v":
-                expectingVersion = true
             case "--master", "-m":
                 parsedArguments.addTagToLastTarget(.master)
-            case "--branch", "-b":
-                expectingBranch = true
+            case "--checkout", "-c":
+                expectingCheckout = true
             default:
                 let target = try Target(kind: targetKind(from: argument), tag: .latestVersion)
                 parsedArguments.targets.append(target)
@@ -129,8 +120,7 @@ extension Arguments {
 
 enum Tag {
     case master
-    case branch(String)
-    case version(Version)
+    case checkout(String)
     case latestVersion
 }
 
@@ -254,10 +244,8 @@ class PackageLoader {
             return latestVersion.string
         case .master:
             return "master"
-        case .branch(let branch):
-            return branch
-        case .version(let version):
-            return version.string
+        case .checkout(let identifier):
+            return identifier
         }
     }
 }
@@ -271,13 +259,13 @@ func printHelp() {
     print("\nUsage:")
     print("- Simply pass a list of pod names or URLs that you want to test drive.")
     print("- You can also specify a platform (iOS, macOS or tvOS) using the '-p' option")
-    print("- To use a specific version, use the '-v' argument (or '-m' for master)")
+    print("- To use a specific version or branch, use the '-c' argument (or '-m' for master)")
     print("\nExamples:")
     print("- testdrive Unbox Wrap Files")
     print("- testdrive https://github.com/johnsundell/unbox.git Wrap Files")
     print("- testdrive Unbox -p tvOS")
-    print("- testdrive Unbox -v 2.3.0")
-    print("- testdrive Unbox -b swift3")
+    print("- testdrive Unbox -c 2.3.0")
+    print("- testdrive Unbox -c swift3")
 }
 
 // MARK: - Script


### PR DESCRIPTION
[Suggestion]
I'd like to use a specific branch(like swift4 branch in near feature) not only version or `master` branch.
What do you think that? If you agree, should I include master in new branch feature?
@JohnSundell 

For instance,
```sh
$ TestDrive Unbox -b swift3
🕵️‍♀️  Finding pod 'Unbox'...
📦  Cloning https://github.com/johnsundell/unbox.git...
📋  Checking out swift3...
🚗  Unbox is ready for test drive

⚡️  Generating workspace at /Users/pixyzehn/Dropbox/Developer/projects/TestDrive/TestDrive-Unbox.xcworkspace/...

🚘  Test driving Unbox
```

If there is no branch,
```sh
$ TestDrive Unbox -b hoge
  Finding pod 'Unbox'...
📦  Cloning https://github.com/johnsundell/unbox.git...
📋  Checking out hoge...

💥  ShellOutError(message: "error: pathspec \'hoge\' did not match any file(s) known to git.", output: "")
```