### PR TITLE
Use HTTPS instead of SSH to clone all dependencies

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -4,32 +4,32 @@
     {
       "package": "Files",
       "reason": null,
-      "repositoryURL": "git@github.com:johnsundell/files.git",
-      "version": "1.7.0"
+      "repositoryURL": "https://github.com/JohnSundell/Files.git",
+      "version": "1.8.0"
     },
     {
       "package": "Releases",
       "reason": null,
-      "repositoryURL": "git@github.com:johnsundell/releases.git",
-      "version": "1.0.1"
+      "repositoryURL": "https://github.com/JohnSundell/Releases.git",
+      "version": "1.0.6"
     },
     {
       "package": "Require",
       "reason": null,
-      "repositoryURL": "git@github.com:johnsundell/require.git",
+      "repositoryURL": "https://github.com/JohnSundell/Require.git",
       "version": "1.0.2"
     },
     {
       "package": "ShellOut",
       "reason": null,
-      "repositoryURL": "git@github.com:johnsundell/shellout.git",
+      "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
       "version": "1.1.0"
     },
     {
       "package": "Xgen",
       "reason": null,
-      "repositoryURL": "git@github.com:johnsundell/xgen.git",
-      "version": "1.0.0"
+      "repositoryURL": "https://github.com/JohnSundell/Xgen.git",
+      "version": "1.0.1"
     }
   ],
   "version": 1

--- a/Package.swift
+++ b/Package.swift
@@ -17,10 +17,10 @@ try scriptData.write(to: mainURL)
 let package = Package(
     name: "TestDrive",
     dependencies: [
-        .Package(url: "git@github.com:johnsundell/xgen.git", majorVersion: 1),
-        .Package(url: "git@github.com:johnsundell/files.git", majorVersion: 1),
-        .Package(url: "git@github.com:johnsundell/shellout.git", majorVersion: 1),
-        .Package(url: "git@github.com:johnsundell/releases.git", majorVersion: 1)
+        .Package(url: "https://github.com/JohnSundell/Xgen.git", majorVersion: 1),
+        .Package(url: "https://github.com/JohnSundell/Files.git", majorVersion: 1),
+        .Package(url: "https://github.com/JohnSundell/ShellOut.git", majorVersion: 1),
+        .Package(url: "https://github.com/JohnSundell/Releases.git", majorVersion: 1)
     ],
     exclude: ["Sources/TestDrive.swift"]
 )


### PR DESCRIPTION
This will enable installation of TestDrive without having an SSH key
setup with GitHub.

Fixed the same issue https://github.com/JohnSundell/Marathon/issues/65.