### PR TITLE
Use HTTPS instead of SSH for repository URL

### DIFF
--- a/Sources/TestDrive.swift
+++ b/Sources/TestDrive.swift
@@ -61,7 +61,7 @@ extension CommandLine {
         if argument.contains("github.com/") {
             let components = argument.components(separatedBy: "github.com/")
 
-            guard let url = URL(string: "git@github.com:\(components[1])") else {
+            guard let url = URL(string: "https://github.com/\(components[1])") else {
                 throw TestDriveError.invalidURL(argument)
             }
 


### PR DESCRIPTION
In addition to https://github.com/JohnSundell/TestDrive/pull/19, I had to use HTTPS instead of SSH for a repository URL.