### PR TITLE
Generate .xcodeproj for Swift package if it doesn't include one

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -247,6 +247,13 @@ class PackageLoader {
             }
         }
 
+        if repositoryFolder.containsFile(named: "Package.swift") {
+            let projectName = "\(name).xcodeproj"
+            try shellOut(to: "swift package generate-xcodeproj --output \(projectName)", at: repositoryFolder.path)
+            print("🚗  \(name) is ready for test drive\n")
+            return Package(name: name, folder: repositoryFolder, projectPath: name + "/" + projectName)
+        }
+
         throw TestDriveError.missingXcodeProject(url)
     }
 


### PR DESCRIPTION
Many projects that support Swift Package Manager include an .xcodeproj in their repo, but for those that don't it would be nice to use them in TestDrive just the same. This change takes effect when a cloned repo doesn't include an .xcodeproj but does include a Package.swift file. In that case it will use `swift package generate-xcodeproj` to create an .xcodeproj in a known location automatically.

**Testing**

I originally wanted this functionality to work with some Vapor-related code, but because it depends on some system libraries that I've found tricky to install, here are some steps that test this new functionality with another, simpler library I found that doesn't include an .xcodeproj:

1. Check out this branch of TestDrive
2. `swift run TestDrive git@github.com:devxoul/Then.git`
3. Build the Then-Package scheme for an iOS simulator
4. Add this to the playground (exact code isn't important, simply an example):
```swift
import Then
import Foundation

let queue = OperationQueue().then {
    $0.maxConcurrentOperationCount = 1
}
```
5. Verify that the playground can import and evaluate the code