### PR TITLE
Surround path in open workspace command with quotes

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -319,7 +319,7 @@ do {
     print("⚡️  Generating workspace at \(workspace.path)...")
     try workspace.generate()
 
-    try shellOut(to: "open \(workspace.path)")
+    try shellOut(to: "open \"\(workspace.path)\"")
     print("\n🚘  Test driving \(packageNames.joined(separator: " + "))")
 
     packageLoader.cleanup()


### PR DESCRIPTION
Closes https://github.com/JohnSundell/TestDrive/issues/22

A workspace path containing spaces would fail to open because the path in the shell command wasn't either surrounded with quotes or had its spaces escaped. This change adds surrounding quotes, which fixes the issue. This can be verified by following the test steps in the original issue.

e.g.
```
❯ pwd
/Users/brandon/Projects/Test Drive

❯ testdrive unbox
🕵️‍♀️  Finding pod 'unbox'...
📦  Cloning https://github.com/johnsundell/unbox.git...
🚢  Resolving latest version...
📋  Checking out 3.0.0...
🚗  Unbox is ready for test drive

⚡️  Generating workspace at /Users/brandon/Projects/Test Drive/TestDrive-Unbox.xcworkspace/...

🚘  Test driving Unbox
```