### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can also install it using the Swift Package Manager:
 ```
 $ git clone https://github.com/JohnSundell/TestDrive.git
 $ cd TestDrive
-$ swift build -c release -Xswiftc -static-stdlib
+$ swift build -c release
 $ cp -f .build/release/TestDrive /usr/local/bin/testdrive
 ```
 


### PR DESCRIPTION
Hi @JohnSundell,
thank you so much for this awesome project!! 🙂 I just wanted to try Ink and run in this error, after installing testdrive from the sources:
```bash
$ testdrive
dyld: Library not loaded: @rpath/libswiftCore.dylib
  Referenced from: /usr/local/bin/testdrive
  Reason: image not found
[1]    66153 abort      testdrive
```

I could fix this by removing the `-Xswiftc -static-stdlib` flags. What do you think?