### PR TITLE
Improve portability of .xcworkspace file by initializing Workspace with relative path

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -308,8 +308,8 @@ do {
     let packageNames = packages.map { $0.name }
 
     let workspaceName = "TestDrive-\(packageNames.joined(separator: "-")).xcworkspace"
-    let workspaceFolder = try FileSystem().createFolder(at: workspaceName)
-    let workspace = Workspace(path: workspaceFolder.path)
+    let workspaceFolder = try Folder.current.createSubfolder(named: workspaceName)
+    let workspace = Workspace(path: workspaceName)
 
     let playground = workspace.addPlayground()
     playground.platform = arguments.platform


### PR DESCRIPTION
Previously, if the `.xcworkspace` was ever moved from it's original location, the FileRefs would be broken because they are added with an absolute path, but embedded within the `.xcworkspace` folder (if it moves, they move).

This PR fixes that by initializing the `Workspace` with a path relative to the working directory. This way, when the playgrounds, packages, or projects are added to the `Workspace`, they're added with a path relative the the `.xcworkspace`. So now if the `.xcworkspace` ever gets moved, the FileRefs will remain in tact. 